### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/earthlings-dev/codex-annex/security/code-scanning/1](https://github.com/earthlings-dev/codex-annex/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the workflow to specify the minimum privileges required. In this case, the workflow only checks out code, builds, and runs tests, with no need to write to repository contents or interact with pull requests, issues, or any external resources that require write permissions. Therefore, the minimal required permission is `contents: read`. This should be applied either at the root level of the workflow (so that it applies to all jobs by default) or to the specific jobs as appropriate. For simplicity and clarity, adding it at the root level (after `name:` and before `on:`) is recommended.

No new imports or method definitions are needed; only a single line of configuration should be added to .github/workflows/rust.yml.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
